### PR TITLE
update parser and test examples

### DIFF
--- a/example/demo.py
+++ b/example/demo.py
@@ -37,6 +37,11 @@ def main():
     demo('The woman is a pianist.')
     demo('A giraffe grazing a tree in the wildness with other wildlife.')
     demo('Cow standing on sidewalk in city area near shops.')
+    demo('She is playing the piano.')  # wrong, contain "she"
+    demo('A woman is next to a piano.')  # wrong
+    demo('A woman is in front of a piano.')  # wrong
+    demo('A woman is standing next to a piano.')  # correct 
+    demo('A bowl of rice, noodle and grains.')  # wrong
 
     print('Input your own sentence. Type q to quit.')
     while True:


### PR DESCRIPTION
1. fix the logic of "Ignore pronouns such as 'it'"
2. add support for cases like "A [woman] is in front of a [piano]." and "A [woman] is next to a [piano]."
3. fix the logic of __flatten_conjunction: make it recursive to get all conjunctions. 